### PR TITLE
bump solana and anchor versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.65
+FROM rust:1.69
 
-ARG SOLANA_VERSION=v1.14.16
-ARG ANCHOR_VERSION=v0.27.0
+ARG SOLANA_VERSION=v1.16.27
+ARG ANCHOR_VERSION=v0.28.0
 
 RUN apt-get update -y 
 RUN apt-get upgrade -y 


### PR DESCRIPTION
Used [Rust release channel from 1.16.27 release](https://github.com/solana-labs/solana/blob/1681f88c1ad92040d28204ad46cf00dc8f4d4d6c/rust-toolchain.toml) and matching versions from local env when upgrading to Anchor 0.28.0.